### PR TITLE
Buffer early stream

### DIFF
--- a/Sources/NIOWebSocketClient/WebSocketHandler.swift
+++ b/Sources/NIOWebSocketClient/WebSocketHandler.swift
@@ -66,8 +66,19 @@ private final class WebSocketHandler: ChannelInboundHandler {
         if var frameSequence = self.frameSequence, frame.fin {
             switch frameSequence.type {
             case .binary:
-                #warning("TODO: pass buffered results")
-            // webSocket.onBinaryCallback(webSocket, frameSequence.binaryBuffer?.readBytes(length: frameSequence.binaryBuffer?.readableBytes ?? 0) ?? [])
+                func _bytes() -> [UInt8] {
+                    guard var buffer = frameSequence.binaryBuffer else {
+                        return []
+                    }
+                    let length = buffer.readableBytes
+                    guard let bytes = buffer.readBytes(length: length) else {
+                        return []
+                    }
+                    return bytes
+                }
+                
+                let bytes = _bytes()
+                webSocket.onBinaryCallback(webSocket, bytes)
             case .text: webSocket.onTextCallback(webSocket, frameSequence.textBuffer)
             default: break
             }


### PR DESCRIPTION
I retry #3 

This PR resolves #1.

Original implementation have this steps.

```
add out WebSocketFrameEncoder
add in WebSocketFrameDecoder
remove inout WebSocketClientUpgradeHandler
upgradePipelineHandler
    remove out HTTPRequestEncoder
    remove in HTTPResponseDecoder
    add inout WebSocketHandler
    notify WebSocket to user
```

This PR changes to it.

```
add out WebSocketFrameEncoder
add in WebSocketFrameDecoder
upgradePipelineHandler
    remove out HTTPRequestEncoder
    remove in HTTPResponseDecoder
      buffered bytes captured by WebSocketClientUpgradeHandler
    add inout WebSocketHandler
upgradeCompleteHandler
    notify WebSocket to user
flush buffered bytes from WebSocketClientUpgradeHandler
remove inout WebSocketClientUpgradeHandler
```

It enable to capture early websocket stream sent out from `HTTPResponseDecoder` at `WebSocketClientUpgradeHandler`.
After `WebSocket` passed to user,
`WebSocketClientUpgradeHandler` flush out captured bytes.

This PR includes #2. 